### PR TITLE
Re-run errored cells after soft_definitions become available

### DIFF
--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -215,28 +215,34 @@ function run_reactive_core!(
         end
 
         implicit_usings = collect_implicit_usings(new_topology, cell)
-        if !PlutoDependencyExplorer.is_resolved(new_topology) && can_help_resolve_cells(new_topology, cell)
-            notebook.topology = new_new_topology = resolve_topology(session, notebook, new_topology, old_workspace_name)
+        needs_resolve = !PlutoDependencyExplorer.is_resolved(new_topology) && can_help_resolve_cells(new_topology, cell)
+        has_implicit_usings = !isempty(implicit_usings)
 
-            if !isempty(implicit_usings)
+        if needs_resolve || has_implicit_usings
+            resolved_topology = needs_resolve ? resolve_topology(session, notebook, new_topology, old_workspace_name) : new_topology
+
+            if has_implicit_usings
                 new_soft_definitions = WorkspaceManager.collect_soft_definitions((session, notebook), implicit_usings)
-                notebook.topology = new_new_topology = with_new_soft_definitions(new_new_topology, cell, new_soft_definitions)
+                resolved_topology = with_new_soft_definitions(resolved_topology, cell, new_soft_definitions)
             end
 
-            # update cache and save notebook because the dependencies might have changed after expanding macros
-            update_dependency_cache!(notebook)
-            save && save_notebook(session, notebook)
-
-            return run_reactive_core!(session, notebook, new_topology, new_new_topology, to_run; save, deletion_hook, user_requested_run, already_run = to_run[1:i])
-        elseif !isempty(implicit_usings)
-            new_soft_definitions = WorkspaceManager.collect_soft_definitions((session, notebook), implicit_usings)
-            notebook.topology = new_new_topology = with_new_soft_definitions(new_topology, cell, new_soft_definitions)
+            notebook.topology = resolved_topology
 
             # update cache and save notebook because the dependencies might have changed after expanding macros
             update_dependency_cache!(notebook)
             save && save_notebook(session, notebook)
 
-            return run_reactive_core!(session, notebook, new_topology, new_new_topology, to_run; save, deletion_hook, user_requested_run, already_run = to_run[1:i])
+            # Cells that are now newly downstream via soft_definitions may have already run (and errored)
+            # before the using cell. Remove errored ones from already_run so they get re-executed.
+            already_run_for_restart = if has_implicit_usings
+                new_soft_defs = resolved_topology.nodes[cell].soft_definitions
+                newly_downstream = Set{Cell}(PlutoDependencyExplorer.where_referenced(resolved_topology, new_soft_defs))
+                filter(c -> !(c ∈ newly_downstream && c.errored), to_run[1:i])
+            else
+                to_run[1:i]
+            end
+
+            return run_reactive_core!(session, notebook, new_topology, resolved_topology, to_run; save, deletion_hook, user_requested_run, already_run = already_run_for_restart)
         end
     end
 

--- a/test/React.jl
+++ b/test/React.jl
@@ -330,6 +330,27 @@ import Pluto.Configuration: Options, EvaluationOptions
         WorkspaceManager.unmake_workspace((🍭, notebook); verbose=false)
     end
 
+    @testset "Soft definitions re-run errored cells" begin
+        # When a cell that references a soft-exported symbol (e.g. `January` from Dates) also
+        # defines a variable used by the `using` cell, the dependency forces it to run BEFORE
+        # the using cell. It errors with UndefVarError because the soft symbol isn't available yet.
+        # After the using cell runs and soft_definitions become available, the errored upstream
+        # cell should be removed from `already_run` and re-executed.
+        notebook = Notebook([
+            Cell("x = January"),
+            Cell("""begin
+                using Dates
+                y = x
+            end"""),
+        ])
+
+        update_run!(🍭, notebook, notebook.cells)
+
+        @test notebook.cells[1] |> noerror  # January should resolve after Dates provides soft_definitions
+
+        WorkspaceManager.unmake_workspace((🍭, notebook); verbose=false)
+    end
+
     @testset "More challenging reactivity of extended function" begin
         notebook = Notebook(Cell.([
             "Base.inv(s::String) = s",


### PR DESCRIPTION
When a cell referencing a soft-exported symbol (e.g. `January` from `using Dates`) is forced to run before the `using` cell due to a hard dependency, it errors with UndefVarError. After the `using` cell executes and provides soft_definitions, the errored cell was not re-executed because it was already in `already_run`.

Fix this by filtering errored cells that are newly downstream of soft_definitions out of `already_run` before restarting the reactive loop.

Also merge two nearly-identical if/elseif branches (needs_resolve and has_implicit_usings) into a single unified block, and rename `new_new_topology` to `resolved_topology`.

This fix is needed to get a notebook to work with Julia 1.12 which worked with 1.11.

This was developed with support from Claude Opus 4.6.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/PatrickHaecker/Pluto.jl", rev="rerun_errored_cells_when_available")
julia> using Pluto
```
