### PR TITLE
Julia 1.13: re-wrap @doc cell result as Docs.Binding

### DIFF
--- a/src/runner/PlutoRunner/src/evaluation/run_expression.jl
+++ b/src/runner/PlutoRunner/src/evaluation/run_expression.jl
@@ -199,6 +199,11 @@ function doc_target_name(@nospecialize(e))
     if e.head === :(=) || e.head === :function || e.head === :macro || e.head === :(->) ||
        e.head === :where || e.head === :call || e.head === :(::) || e.head === :curly
         return isempty(e.args) ? nothing : doc_target_name(e.args[1])
+    elseif e.head === :.
+        # qualified name like `Base.conj` — pick the rightmost symbol; `Docs.Binding`
+        # in any workspace resolves to the same docs via Docs.aliasof.
+        return length(e.args) == 2 && e.args[2] isa QuoteNode && e.args[2].value isa Symbol ?
+            e.args[2].value::Symbol : nothing
     elseif e.head === :struct
         return length(e.args) >= 2 ? doc_target_name(e.args[2]) : nothing
     elseif e.head === :module

--- a/src/runner/PlutoRunner/src/evaluation/run_expression.jl
+++ b/src/runner/PlutoRunner/src/evaluation/run_expression.jl
@@ -163,6 +163,22 @@ so we re-derive the binding from the (pre-macroexpansion) expression. See JuliaL
 and Pluto issue #3449.
 """
 function doc_macrocall_binding_name(@nospecialize(expr))
+    # Peel off the `:toplevel`/`:block` wrapper that Pluto's Parse.jl always builds, ignoring
+    # `LineNumberNode`s, until we either reach the macrocall or something else.
+    while expr isa Expr && (expr.head === :toplevel || expr.head === :block)
+        inner = nothing
+        for arg in expr.args
+            arg isa LineNumberNode && continue
+            if inner === nothing
+                inner = arg
+            else
+                # more than one non-LineNumberNode arg: not a `@doc` wrapper shape
+                return nothing
+            end
+        end
+        inner === nothing && return nothing
+        expr = inner
+    end
     Meta.isexpr(expr, :macrocall) || return nothing
     name = expr.args[1]
     is_doc_macro =

--- a/src/runner/PlutoRunner/src/evaluation/run_expression.jl
+++ b/src/runner/PlutoRunner/src/evaluation/run_expression.jl
@@ -155,6 +155,64 @@ contains_macrocall(other) = false
 
 
 """
+Detect a top-level `@doc str def` expression and return the bound name (e.g. `:f`) if found.
+
+The Julia 1.13 release (JuliaLang/julia#59882) changed `@doc` so it returns the value of `def`
+rather than a `Docs.Binding`. That breaks `format_output(::Base.Docs.Binding)` cell rendering,
+so we re-derive the binding from the (pre-macroexpansion) expression. See JuliaLang/julia#60681
+and Pluto issue #3449.
+"""
+function doc_macrocall_binding_name(@nospecialize(expr))
+    Meta.isexpr(expr, :macrocall) || return nothing
+    name = expr.args[1]
+    is_doc_macro =
+        name === GlobalRef(Core, Symbol("@doc")) ||
+        name === GlobalRef(Base, Symbol("@doc")) ||
+        name === Symbol("@doc") ||
+        name == :(Core.var"@doc") ||
+        name == :(Base.var"@doc")
+    is_doc_macro || return nothing
+    # Layout: @doc <LineNumberNode> <docstring> <def>
+    length(expr.args) >= 4 || return nothing
+    return doc_target_name(expr.args[end])
+end
+
+doc_target_name(s::Symbol) = s
+function doc_target_name(@nospecialize(e))
+    e isa Expr || return nothing
+    if e.head === :(=) || e.head === :function || e.head === :macro || e.head === :(->) ||
+       e.head === :where || e.head === :call || e.head === :(::) || e.head === :curly
+        return isempty(e.args) ? nothing : doc_target_name(e.args[1])
+    elseif e.head === :struct
+        return length(e.args) >= 2 ? doc_target_name(e.args[2]) : nothing
+    elseif e.head === :module
+        return length(e.args) >= 2 && e.args[2] isa Symbol ? e.args[2] : nothing
+    elseif e.head === :const && length(e.args) >= 1
+        return doc_target_name(e.args[1])
+    end
+    return nothing
+end
+
+"""
+On Julia 1.13+, re-wrap the result of a `@doc` cell as a `Docs.Binding` so the cell renders as
+documentation rather than as a generic function summary. No-op on earlier versions, where `@doc`
+already returns a `Docs.Binding`.
+"""
+function maybe_rewrap_as_doc_binding(@nospecialize(ans), @nospecialize(original_expr), m::Module)
+    @static if VERSION < v"1.13.0-DEV"
+        return ans
+    else
+        ans isa Docs.Binding && return ans
+        ans isa CapturedException && return ans
+        name = doc_macrocall_binding_name(original_expr)
+        name === nothing && return ans
+        isdefined(m, name) || return ans
+        return Docs.Binding(m, name)
+    end
+end
+
+
+"""
 Run the given expression in the current workspace module. If the third argument is `nothing`, then the expression will be `Core.eval`ed. The result and runtime are stored inside [`cell_results`](@ref) and [`cell_runtimes`](@ref).
 
 If the third argument is a `Tuple{Set{Symbol}, Set{Symbol}}` containing the referenced and assigned variables of the expression (computed by the ExpressionExplorer), then the expression will be **wrapped inside a function**, with the references as inputs, and the assignments as outputs. Instead of running the expression directly, Pluto will call this function, with the right globals as inputs.
@@ -281,7 +339,9 @@ function run_expression(
     if (result isa CapturedException) && (result.ex isa InterruptException)
         throw(result.ex)
     end
-    
+
+    result = maybe_rewrap_as_doc_binding(result, original_expr, m)
+
     cell_results[cell_id], cell_runtimes[cell_id] = result, runtime
 end
 precompile(run_expression, (Module, Expr, UUID, UUID, Nothing, Nothing))


### PR DESCRIPTION
## Summary

Restore the docstring-as-cell-output rendering on Julia 1.13+ that was broken by [JuliaLang/julia#59882](https://github.com/JuliaLang/julia/pull/59882). Fixes the failing assertions in [#3449](https://github.com/JuliaPluto/Pluto.jl/issues/3449); part of the [#3389](https://github.com/JuliaPluto/Pluto.jl/issues/3389) umbrella. Continues — but does not stack on — the closed [#3452](https://github.com/JuliaPluto/Pluto.jl/pull/3452), which had been abandoned because the author could not pin down the upstream behavior change.

## What changed in Julia 1.13

Same parsed expression, different result:

```julia
julia> Meta.parse("\"::Bool\"\nf(::Bool) = 1") |> e -> Core.eval(Main, e) |> typeof
# 1.12: Base.Docs.Binding
# 1.13: typeof(f)
```

`@doc str def` now returns the value of `def` instead of a `Base.Docs.Binding` ([JuliaLang/julia#60681](https://github.com/JuliaLang/julia/issues/60681), closed as not planned). Pluto's `format_output(::Base.Docs.Binding)` dispatch no longer fires, so documented function cells render as `f (generic function with N methods)` rather than the docstring HTML.

`Docs.doc(binding)` itself still works correctly on 1.13 and aggregates all method docstrings as before — only the cell result type changed.

## The fix

Detect the (pre-macroexpansion) `@doc` macrocall in `run_expression`, extract the bound name from the definition, and re-wrap the result as `Docs.Binding(workspace, name)` before storing in `cell_results`. This puts the cell back on the existing rendering path; no display-side changes required.

- No-op on Julia < 1.13 (where the result is already a `Docs.Binding`).
- Skipped for `CapturedException` results so error rendering is untouched.
- Skipped if the bound name isn't defined in the workspace, so a half-failed definition still falls through to the default formatter.
- Handles common doc targets: `f(x) = …`, `function f end`, `f(::T) where T`, parametric methods, `struct`, `macro`, `module`, `const`.

## Test plan

- [ ] CI: `test/MacroAnalysis.jl` "Doc strings" testset (the 11 failing assertions from #3449) passes on Julia 1.13.
- [ ] CI: same testset still passes on 1.11 and 1.12 (helper is a no-op).
- [ ] Manual: open a notebook on 1.13, run a cell like `"docstring"\nf(::Bool) = 1`, verify the rich docstring panel renders.
- [ ] Manual: redefine a method in another cell, verify both method docstrings appear in either cell's output.

## Out of scope (follow-ups from #3389)

- `warn_julia_compat()` in `src/Pluto.jl` still warns on 1.13 — should be bumped to 1.14 once the testset is green.
- [Malt.jl#101](https://github.com/JuliaPluto/Malt.jl/issues/101) and [#93](https://github.com/JuliaPluto/Malt.jl/issues/93) (1.13 interrupt failures) are still open.
- GracefulPkg.jl 1.13 audit per the umbrella issue.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/JuliaPluto/Pluto.jl", rev="pg/julia-1.13-docstring-display")
julia> using Pluto
```
