### PR TITLE
Update 1.13 docstring rendering to properly include structs + macros

### DIFF
--- a/src/runner/PlutoRunner/src/evaluation/run_expression.jl
+++ b/src/runner/PlutoRunner/src/evaluation/run_expression.jl
@@ -199,6 +199,11 @@ function doc_target_name(@nospecialize(e))
     if e.head === :(=) || e.head === :function || e.head === :macro || e.head === :(->) ||
        e.head === :where || e.head === :call || e.head === :(::) || e.head === :curly
         return isempty(e.args) ? nothing : doc_target_name(e.args[1])
+    elseif e.head === :.
+        # qualified name like `Base.conj` — pick the rightmost symbol; `Docs.Binding`
+        # in any workspace resolves to the same docs via Docs.aliasof.
+        return length(e.args) == 2 && e.args[2] isa QuoteNode && e.args[2].value isa Symbol ?
+            e.args[2].value::Symbol : nothing
     elseif e.head === :struct
         return length(e.args) >= 2 ? doc_target_name(e.args[2]) : nothing
     elseif e.head === :module

--- a/src/runner/PlutoRunner/src/evaluation/run_expression.jl
+++ b/src/runner/PlutoRunner/src/evaluation/run_expression.jl
@@ -163,6 +163,22 @@ so we re-derive the binding from the (pre-macroexpansion) expression. See JuliaL
 and Pluto issue #3449.
 """
 function doc_macrocall_binding_name(@nospecialize(expr))
+    # Peel off the `:toplevel`/`:block` wrapper that Pluto's Parse.jl always builds, ignoring
+    # `LineNumberNode`s, until we either reach the macrocall or something else.
+    while expr isa Expr && (expr.head === :toplevel || expr.head === :block)
+        inner = nothing
+        for arg in expr.args
+            arg isa LineNumberNode && continue
+            if inner === nothing
+                inner = arg
+            else
+                # more than one non-LineNumberNode arg: not a `@doc` wrapper shape
+                return nothing
+            end
+        end
+        inner === nothing && return nothing
+        expr = inner
+    end
     Meta.isexpr(expr, :macrocall) || return nothing
     name = expr.args[1]
     is_doc_macro =

--- a/src/runner/PlutoRunner/src/evaluation/run_expression.jl
+++ b/src/runner/PlutoRunner/src/evaluation/run_expression.jl
@@ -155,6 +155,64 @@ contains_macrocall(other) = false
 
 
 """
+Detect a top-level `@doc str def` expression and return the bound name (e.g. `:f`) if found.
+
+The Julia 1.13 release (JuliaLang/julia#59882) changed `@doc` so it returns the value of `def`
+rather than a `Docs.Binding`. That breaks `format_output(::Base.Docs.Binding)` cell rendering,
+so we re-derive the binding from the (pre-macroexpansion) expression. See JuliaLang/julia#60681
+and Pluto issue #3449.
+"""
+function doc_macrocall_binding_name(@nospecialize(expr))
+    Meta.isexpr(expr, :macrocall) || return nothing
+    name = expr.args[1]
+    is_doc_macro =
+        name === GlobalRef(Core, Symbol("@doc")) ||
+        name === GlobalRef(Base, Symbol("@doc")) ||
+        name === Symbol("@doc") ||
+        name == :(Core.var"@doc") ||
+        name == :(Base.var"@doc")
+    is_doc_macro || return nothing
+    # Layout: @doc <LineNumberNode> <docstring> <def>
+    length(expr.args) >= 4 || return nothing
+    return doc_target_name(expr.args[end])
+end
+
+doc_target_name(s::Symbol) = s
+function doc_target_name(@nospecialize(e))
+    e isa Expr || return nothing
+    if e.head === :(=) || e.head === :function || e.head === :macro || e.head === :(->) ||
+       e.head === :where || e.head === :call || e.head === :(::) || e.head === :curly
+        return isempty(e.args) ? nothing : doc_target_name(e.args[1])
+    elseif e.head === :struct
+        return length(e.args) >= 2 ? doc_target_name(e.args[2]) : nothing
+    elseif e.head === :module
+        return length(e.args) >= 2 && e.args[2] isa Symbol ? e.args[2] : nothing
+    elseif e.head === :const && length(e.args) >= 1
+        return doc_target_name(e.args[1])
+    end
+    return nothing
+end
+
+"""
+On Julia 1.13+, re-wrap the result of a `@doc` cell as a `Docs.Binding` so the cell renders as
+documentation rather than as a generic function summary. No-op on earlier versions, where `@doc`
+already returns a `Docs.Binding`.
+"""
+function maybe_rewrap_as_doc_binding(@nospecialize(ans), @nospecialize(original_expr), m::Module)
+    @static if VERSION < v"1.13.0-DEV"
+        return ans
+    else
+        ans isa Docs.Binding && return ans
+        ans isa CapturedException && return ans
+        name = doc_macrocall_binding_name(original_expr)
+        name === nothing && return ans
+        isdefined(m, name) || return ans
+        return Docs.Binding(m, name)
+    end
+end
+
+
+"""
 Run the given expression in the current workspace module. If the third argument is `nothing`, then the expression will be `Core.eval`ed. The result and runtime are stored inside [`cell_results`](@ref) and [`cell_runtimes`](@ref).
 
 If the third argument is a `Tuple{Set{Symbol}, Set{Symbol}}` containing the referenced and assigned variables of the expression (computed by the ExpressionExplorer), then the expression will be **wrapped inside a function**, with the references as inputs, and the assignments as outputs. Instead of running the expression directly, Pluto will call this function, with the right globals as inputs.
@@ -281,7 +339,9 @@ function run_expression(
     if (result isa CapturedException) && (result.ex isa InterruptException)
         throw(result.ex)
     end
-    
+
+    result = maybe_rewrap_as_doc_binding(result, original_expr, m)
+
     cell_results[cell_id], cell_runtimes[cell_id] = result, runtime
 end
 precompile(run_expression, (Module, Expr, UUID, UUID, Nothing, Nothing))

--- a/src/runner/PlutoRunner/src/evaluation/run_expression.jl
+++ b/src/runner/PlutoRunner/src/evaluation/run_expression.jl
@@ -196,16 +196,24 @@ end
 doc_target_name(s::Symbol) = s
 function doc_target_name(@nospecialize(e))
     e isa Expr || return nothing
-    if e.head === :(=) || e.head === :function || e.head === :macro || e.head === :(->) ||
-       e.head === :where || e.head === :call || e.head === :(::) || e.head === :curly
+    if e.head === :(=) || e.head === :function || e.head === :(->) ||
+       e.head === :where || e.head === :call || e.head === :(::) || e.head === :curly ||
+       e.head === :(<:)
+        # `:(<:)` shows up in `struct Foo <: Bar` and `abstract type Foo <: Bar end` signatures.
         return isempty(e.args) ? nothing : doc_target_name(e.args[1])
     elseif e.head === :.
         # qualified name like `Base.conj` — pick the rightmost symbol; `Docs.Binding`
         # in any workspace resolves to the same docs via Docs.aliasof.
         return length(e.args) == 2 && e.args[2] isa QuoteNode && e.args[2].value isa Symbol ?
             e.args[2].value::Symbol : nothing
+    elseif e.head === :macro
+        # Macros are bound under `var"@name"`, not `name`, so prefix the extracted name.
+        inner = isempty(e.args) ? nothing : doc_target_name(e.args[1])
+        return inner === nothing ? nothing : Symbol("@", inner)
     elseif e.head === :struct
         return length(e.args) >= 2 ? doc_target_name(e.args[2]) : nothing
+    elseif e.head === :abstract || e.head === :primitive
+        return length(e.args) >= 1 ? doc_target_name(e.args[1]) : nothing
     elseif e.head === :module
         return length(e.args) >= 2 && e.args[2] isa Symbol ? e.args[2] : nothing
     elseif e.head === :const && length(e.args) >= 1

--- a/test/MacroAnalysis.jl
+++ b/test/MacroAnalysis.jl
@@ -918,6 +918,69 @@ import Memoize: @memoize
         cleanup(🍭, notebook)
     end
 
+    @testset "Doc strings on macros, abstract/primitive types and subtyped structs" begin
+        notebook = Notebook(Cell.([
+            raw"""
+            "struct with supertype doc"
+            struct MyDocStruct <: Number
+                a::Int
+            end
+            """,
+            raw"""
+            "parametric struct with supertype doc"
+            struct MyDocStruct2{T} <: Number
+                a::T
+            end
+            """,
+            raw"""
+            "abstract type doc"
+            abstract type MyDocAbstract end
+            """,
+            raw"""
+            "abstract type with supertype doc"
+            abstract type MyDocAbstract2 <: Number end
+            """,
+            raw"""
+            "primitive type doc"
+            primitive type MyDocPrim 32 end
+            """,
+            raw"""
+            "macro doc"
+            macro mydocmac(x)
+                x
+            end
+            """,
+        ]))
+
+        update_run!(🍭, notebook, notebook.cells)
+        @test all(noerror, notebook.cells)
+
+        is_doc_binding(cell) = occursin("pluto-docs-binding", cell.output.body)
+
+        struct_cell, param_struct_cell, abstract_cell, abstract_sub_cell, primitive_cell, macro_cell = notebook.cells
+
+        @test is_doc_binding(struct_cell)
+        @test occursin("struct with supertype doc", struct_cell.output.body)
+
+        @test is_doc_binding(param_struct_cell)
+        @test occursin("parametric struct with supertype doc", param_struct_cell.output.body)
+
+        @test is_doc_binding(abstract_cell)
+        @test occursin("abstract type doc", abstract_cell.output.body)
+
+        @test is_doc_binding(abstract_sub_cell)
+        @test occursin("abstract type with supertype doc", abstract_sub_cell.output.body)
+
+        @test is_doc_binding(primitive_cell)
+        @test occursin("primitive type doc", primitive_cell.output.body)
+
+        @test is_doc_binding(macro_cell)
+        @test occursin("macro doc", macro_cell.output.body)
+        @test occursin("@mydocmac", macro_cell.output.body)
+
+        cleanup(🍭, notebook)
+    end
+
     @testset "Delete methods from macros" begin
         🍭 = ServerSession()
         🍭.options.evaluation.workspace_use_distributed = false

--- a/test/MacroAnalysis.jl
+++ b/test/MacroAnalysis.jl
@@ -918,7 +918,7 @@ import Memoize: @memoize
         cleanup(🍭, notebook)
     end
 
-    @testset "Doc strings on macros, abstract/primitive types and subtyped structs" begin
+    @testset "Doc strings on macros types structs" begin
         notebook = Notebook(Cell.([
             raw"""
             "struct with supertype doc"


### PR DESCRIPTION
Suggested and implemented by Claude Sonnet.

* doc_target_name extended to handle :<: (subtyped structs/abstract types), :abstract, and :primitive heads
* plus a proper :macro case that returns Symbol("@name") instead of the bare name.
* Regression tests added to test/MacroAnalysis.jl covering macros, abstract types (with/without supertype), primitive types, and subtyped/parametric structs.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/j-fu/Pluto.jl", rev="julia-1.13-struct-docstrings")
julia> using Pluto
```
