### PR TITLE
add integration for AbstractDictionary

### DIFF
--- a/src/runner/PlutoRunner/src/integrations.jl
+++ b/src/runner/PlutoRunner/src/integrations.jl
@@ -204,6 +204,46 @@ const integrations = Integration[
             preprocess_log_msg(ps::ProgressLogging.ProgressString) = ps.progress.name
         end,
     ),
+    Integration(
+        id = Base.PkgId(UUID("85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"), "Dictionaries"),
+        code = quote
+            pluto_showable(::MIME"application/vnd.pluto.tree+object", ::Dictionaries.AbstractDictionary) = true
+            function tree_data(@nospecialize(x::Dictionaries.AbstractDictionary{<:Any,<:Any}), context::Context)
+                if Base.show_circular(context, x)
+                    return circular(x)
+                else
+                    depth = get(context, :tree_viewer_depth, 0)
+                    recur_io = IOContext(context, Pair{Symbol,Any}(:SHOWN_SET, x), Pair{Symbol,Any}(:tree_viewer_depth, depth + 1))
+
+                    elements = []
+
+                    my_limit = get_my_display_limit(x, 1, depth, context, tree_display_limit, tree_display_limit_increase)
+                    row_index = 1
+
+                    k=keys(x)
+                    v=values(x)
+                    for pair in zip(k,v)
+                        k, v = pair
+                        if row_index <= my_limit
+                            push!(elements, (format_output_default(k, recur_io), format_output_default(v, recur_io)))
+                        else
+                            push!(elements, "more")
+                            break
+                        end
+                        row_index += 1
+                    end
+                    
+                    Dict{Symbol,Any}(
+                        :prefix => string(typeof(x)),
+                        :prefix_short => string(typeof(x) |> trynameof),
+                        :objectid => objectid2str(x),
+                        :type => :Dict,
+                        :elements => elements
+                    )
+                end
+            end
+        end,
+    ),
 ]
 
 function load_integration_if_needed(integration::Integration)


### PR DESCRIPTION
Hi, I am opening this because I cannot find a way outside of Pluto to do it. I want to update Pluto's integrations.jl to make AbstractDictionary from Dictionaries.jl display as nice expandable trees in the same way as Base Dict does already. This means that the dictionary and items inside are inspectable which was not possible before. It seems better to fix the display rather than choose different types because of how they display in pluto.

This PR:
<img width="539" height="73" alt="image" src="https://github.com/user-attachments/assets/f7eeb11f-9c35-42ac-bd3d-028789c3a1c8" />
and expanded:
<img width="536" height="139" alt="image" src="https://github.com/user-attachments/assets/7ef9e070-0762-4209-9fb8-29f8a7288fba" />

Main:
<img width="533" height="87" alt="image" src="https://github.com/user-attachments/assets/994e25ae-4316-44d2-a54e-9d57c8e1baa0" />


It is particularly useful for a long type that quickly stop getting printed otherwise.
This PR:
<img width="536" height="185" alt="image" src="https://github.com/user-attachments/assets/79351745-9bc2-4dad-a9f0-fad260670125" />

Main:
<img width="536" height="99" alt="image" src="https://github.com/user-attachments/assets/45576940-07ba-49e8-87a3-690743fad9da" />

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/hogrobinson/Pluto.jl", rev="display_AbstractDictionary_as_tree")
julia> using Pluto
```
