### PR TITLE
fix: sandbox the iframe used for full-document HTML output

### DIFF
--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -236,25 +236,15 @@ register(OutputBody, "pluto-display", ["mime", "body", "cell_id", "persist_js_st
 let IframeContainer = ({ body }) => {
     let iframeref = useRef()
     useLayoutEffect(() => {
-        let url = URL.createObjectURL(new Blob([body], { type: "text/html" }))
+        // The iframe is sandboxed without `allow-same-origin`, so the host cannot reach into its document.
+        // The iframe-resizer content script is therefore appended to the HTML itself, and the two sides talk over postMessage.
+        let resizer_script = /** @type {HTMLScriptElement} */ (document.querySelector("#iframe-resizer-content-window-script"))
+        let resizer_tag = resizer_script == null ? "" : `<script src="${resizer_script.src}" crossorigin="anonymous"></script>`
+        let url = URL.createObjectURL(new Blob([body, resizer_tag], { type: "text/html" }))
         iframeref.current.src = url
 
         run(async () => {
             await new Promise((resolve) => iframeref.current.addEventListener("load", () => resolve(null)))
-
-            /** @type {Document} */
-            let iframeDocument = iframeref.current.contentWindow.document
-            /** Grab the <script> tag for the iframe content window resizer */
-            let original_script_element = /** @type {HTMLScriptElement} */ (document.querySelector("#iframe-resizer-content-window-script"))
-
-            // Insert iframe resizer inside the iframe
-            let iframe_resizer_content_script = iframeDocument.createElement("script")
-            iframe_resizer_content_script.src = original_script_element.src
-            iframe_resizer_content_script.crossOrigin = "anonymous"
-            iframeDocument.head.appendChild(iframe_resizer_content_script)
-
-            // Apply iframe resizer from the host side
-            new Promise((resolve) => iframe_resizer_content_script.addEventListener("load", () => resolve(null)))
             // @ts-ignore
             window.iFrameResize({ checkOrigin: false }, iframeref.current)
         })
@@ -267,6 +257,7 @@ let IframeContainer = ({ body }) => {
         src=""
         ref=${iframeref}
         frameborder="0"
+        sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals allow-downloads"
         allow="accelerometer; ambient-light-sensor; autoplay; battery; camera; display-capture; document-domain; encrypted-media; execution-while-not-rendered; execution-while-out-of-viewport; fullscreen; geolocation; gyroscope; layout-animations; legacy-image-formats; magnetometer; microphone; midi; navigation-override; oversized-images; payment; picture-in-picture; publickey-credentials-get; sync-xhr; usb; wake-lock; screen-wake-lock; vr; web-share; xr-spatial-tracking"
         allowfullscreen
     ></iframe>`


### PR DESCRIPTION
## Problem

`text/html` cell output that starts with `<!DOCTYPE` or `<html` is rendered in its own iframe (`IframeContainer` in `frontend/components/CellOutput.js`), loaded from a `blob:` URL. A `blob:` URL inherits the origin of the page that created it, and the iframe had no `sandbox` attribute, so scripts inside that document ran with full same-origin access to the editor page: `parent.document`, `parent.window.*`, cookies, and credentialed fetches to whatever the editor origin can reach.

In a plain local Pluto this is the same trust level as running the notebook's Julia code. It matters for deployments that serve Pluto to more than one user on a shared origin, where the editor page carries credentials that the notebook author should not get (reported to JuliaHub via HackerOne).

## Change

- Add `sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals allow-downloads"` to the iframe. Without `allow-same-origin` the blob document gets an opaque origin: scripts still run, but `parent.document` and friends throw `SecurityError`, and network requests carry no credentials for the editor origin. Forms, downloads (e.g. Plotly's "save as PNG"), `alert()`, and `target=_blank` links keep working.
- The host can no longer reach into `contentWindow.document` to inject the iframe-resizer content script, so the `<script>` tag is appended to the HTML before the blob is created. iframe-resizer already talks host↔content over `postMessage` with `checkOrigin: false`, so resizing works unchanged with the opaque origin.

## Verification

Local run with a notebook whose cell outputs a full HTML document containing a 700px-tall element and a script that tries `parent.document.title`. Checked with Puppeteer:

- iframe has the `sandbox` attribute without `allow-same-origin`
- iframe-resizer grew the frame to fit the content (height > 650px)
- inside the frame, `parent.document` access throws and `window.origin === "null"`
- ordinary inline `text/html` output (no DOCTYPE) still executes its `<script>` as before — that path is unchanged

`tsc --noEmit --strictNullChecks false` reports no errors in `frontend/components`.

## Note

This is hardening, not a full boundary: while a notebook is running, Pluto also executes `<script>` tags in ordinary inline HTML output (`execute_scripttags`) — that is a feature that PlutoUI and `@htl` depend on. Deployments that open untrusted notebooks should open them in Safe Preview (`execution_allowed=false`), which disables both paths until the user explicitly runs the notebook.


## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/JuliaPluto/Pluto.jl", rev="pg/sandbox-fullpage-iframe")
julia> using Pluto
```
